### PR TITLE
build: fix error due to capability.h

### DIFF
--- a/pathauditor/pathauditor.cc
+++ b/pathauditor/pathauditor.cc
@@ -18,7 +18,6 @@
 #include <fcntl.h>
 #include <linux/magic.h>
 #include <stdio.h>
-#include <sys/capability.h>
 #include <sys/ioctl.h>
 #include <sys/mount.h>
 #include <sys/stat.h>


### PR DESCRIPTION
In path auditor.cc sys/capability.h was included it causes bad
interaction with sys/stat.h:
In file included from /usr/include/bits/statx.h:30,
from /usr/include/sys/stat.h:446,
from pathauditor/pathauditor.cc:24:
/usr/include/linux/stat.h:57:2: error: '__s64' does not name a type
57 |  __s64 tv_sec;
|  ^~~~~
Removing this useless include fixed that build error.

Signed-off-by: Clement Magnard <magnar_c@epita.fr>