### PR TITLE
build: warning: fixed warning

### DIFF
--- a/pathauditor/pathauditor.cc
+++ b/pathauditor/pathauditor.cc
@@ -221,7 +221,7 @@ StatusOr<bool> PathIsUserControlled(const ProcessInformation &proc_info,
 
   std::deque<std::string> path_queue = absl::StrSplit(path, '/', absl::SkipEmpty());
 
-  for (int i = 0; i < max_iteration_count; i++) {
+  for (size_t i = 0; i < max_iteration_count; i++) {
     if (path_queue.empty()) {
       return false;
     }
@@ -290,7 +290,7 @@ StatusOr<bool> PathIsUserControlled(const ProcessInformation &proc_info,
           return FailedPreconditionError(
               absl::StrCat("Could not read link for path element ", elem));
         }
-        if (link_len >= link_buf.memsize()) {
+        if ((size_t)link_len >= link_buf.memsize()) {
           return FailedPreconditionError(
               absl::StrCat("Link is larger than PATH_MAX ",
                            std::string(link_buf.data(), link_buf.memsize())));


### PR DESCRIPTION
Fixed 2 warnings:
- Changed signness of a variable
- cast ssize_t to size_t because the negative case has been checked

Signed-off-by: Clement Magnard <magnar_c@epita.fr>